### PR TITLE
print proper error message

### DIFF
--- a/depchase
+++ b/depchase
@@ -360,7 +360,11 @@ def solve(solver, pkgnames, selfhost=False):
         assert not sel.isempty(), "Could not find package for {}".format(n)
         jobs += sel.jobs(solv.Job.SOLVER_INSTALL)
     problems = solver.solve(jobs)
-    assert not problems
+    if problems:
+        print ("ERROR:")
+        for problem in problems:
+            print (problem)
+        sys.exit(1)
 
     print_transaction(pool, solver.transaction())
     candq = [s for s in solver.transaction().newpackages() if s.arch not in ("src", "nosrc")]


### PR DESCRIPTION
When running this command: 

```
./depchase -c repos.cfg -a x86_64 resolve freeipa-client freeipa-client-common freeipa-common freeipa-desktop-profile freeipa-python-compat freeipa-server freeipa-server-common freeipa-server-dns freeipa-server-trust-ad
```

I was getting the following error which was not very helpful:

```
Traceback (most recent call last):
  File "./depchase", line 526, in <module>
    cli(obj={})
  File "/usr/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "./depchase", line 470, in resolve
    binary, source = solve(solver, pkgnames, selfhost=selfhost)
  File "./depchase", line 364, in solve
    assert not problems
AssertionError
```

This PR changes it to the following:

```
ERROR:
nothing provides /usr/lib64/libnssckbi.so needed by mod_nss-1.0.14-5.fc27.x86_64
nothing provides /usr/lib64/libnssckbi.so needed by mod_nss-1.0.14-5.fc27.x86_64
nothing provides /usr/lib64/libnssckbi.so needed by mod_nss-1.0.14-5.fc27.x86_64
```